### PR TITLE
Fix crash when deserializing DynamoDB records with NULL properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ var toModel = {
       return toModel.N(num, schema.items)
     })
   },
-  NULL: function(value, schema) {
-    return null;
+  NULL: function() {
+    return null
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -44,6 +44,9 @@ var toModel = {
     return value.map(function (num) {
       return toModel.N(num, schema.items)
     })
+  },
+  NULL: function(value, schema) {
+    return null;
   }
 }
 

--- a/test/fromDynamoItemToModel.spec.js
+++ b/test/fromDynamoItemToModel.spec.js
@@ -179,6 +179,17 @@ describe('fromDynamoItemToModel', function () {
       var model = transformer.fromDynamoItemToModel(schema, item)
       assert(model.nestedObject.number === parseInt(item.nestedObject.M.number.N, 10))
     })
+
+    it('NULL', function () {
+      var item = {
+        nullProperty: {
+          NULL: true
+        }
+      }
+
+      var model = transformer.fromDynamoItemToModel(schema, item)
+      assert(model.nullProperty === null)
+    })
   })
 
 })


### PR DESCRIPTION
DynamoDB records can have NULL properties - currently, json-schema-dynamo doesn't handle them and crashes when one is encountered.

This change adds support for deserializing records with NULLs.